### PR TITLE
Add a naive normalization method for #11

### DIFF
--- a/src/QAMachine.ts
+++ b/src/QAMachine.ts
@@ -6,6 +6,30 @@ export default class QAMachine {
 
   protected idx:number = 0;
 
+  // a naive normalizer
+  private static normalize(m:QAMachine, obj:any) : number {
+    if (!obj) return obj;
+    let ret : State = {};
+    let idx = m.state(ret);
+    if (obj.question) ret.question = obj.question
+    if (obj.payload) ret.payload = obj.payload
+    if (obj.message) ret.message = obj.message
+    if (obj.answers) {
+      ret.answers = {};
+      let keys = Object.keys(obj.answers);
+      keys.forEach(k => {
+        ret.answers[k] = QAMachine.normalize(m, obj.answers[k]);
+      });
+    }
+    return idx;
+  }
+
+  public static fromJSON(obj:any) : QAMachine {
+    let m = new QAMachine({});
+    QAMachine.normalize(m, obj);
+    return m;
+  }
+
   constructor(states:any) {
     this.states = states || {};
   }

--- a/test/QAMachineTest.js
+++ b/test/QAMachineTest.js
@@ -36,4 +36,44 @@ describe('QAMachine', function () {
         last = m.query(["yes", "no"], init);
         chai_1.assert.equal("question4", last.question);
     });
+    it("normalize JSON", function () {
+        var json = {
+            "question": "Q1",
+            "payload": { "foo": "bar" },
+            "answers": {
+                "A1": {
+                    "question": "Q2",
+                    "answers": {
+                        "A3": null,
+                        "A4": {
+                            "question": "Q3",
+                            "answers": {
+                                "A5": null,
+                                "A6": null
+                            }
+                        }
+                    }
+                },
+                "A2": {
+                    "question": "Q4",
+                    "answers": {
+                        "A7": null
+                    }
+                }
+            }
+        };
+        var m = QAMachine_1["default"].fromJSON(json);
+        chai_1.assert.equal(m.get(0).question, "Q1");
+        chai_1.assert.equal(m.get(1).question, "Q2");
+        chai_1.assert.equal(m.get(2).question, "Q3");
+        chai_1.assert.equal(m.get(3).question, "Q4");
+        for (var _i = 0, _a = [0, 1, 2, 3]; _i < _a.length; _i++) {
+            var i = _a[_i];
+            var s = m.get(i);
+            for (var k in s.answers) {
+                var a = s.answers[k];
+                chai_1.assert.isOk(typeof a === "number" || a === null);
+            }
+        }
+    });
 });

--- a/test/QAMachineTest.ts
+++ b/test/QAMachineTest.ts
@@ -39,4 +39,45 @@ describe('QAMachine', () => {
     last = m.query(["yes", "no"], init);
     assert.equal("question4", last.question);
   });
+
+  it("normalize JSON", () => {
+		const json = {
+			"question": "Q1",
+			"payload": { "foo": "bar" },
+			"answers": {
+				"A1": {
+					"question": "Q2",
+					"answers": {
+						"A3": null,
+						"A4": {
+							"question": "Q3",
+							"answers": {
+								"A5": null,
+								"A6": null
+							}
+						}
+					}
+				},
+				"A2": {
+					"question": "Q4",
+					"answers": {
+						"A7": null
+					}
+				}
+			}
+		};
+
+    const m = QAMachine.fromJSON(json);
+    assert.equal(m.get(0).question, "Q1");
+    assert.equal(m.get(1).question, "Q2");
+    assert.equal(m.get(2).question, "Q3");
+    assert.equal(m.get(3).question, "Q4");
+    for (let i of [0, 1, 2, 3]) {
+      let s = m.get(i);
+      for (let k in s.answers) {
+        let a = s.answers[k];
+        assert.isOk(typeof a === "number" || a === null);
+			}
+		}
+  });
 });


### PR DESCRIPTION
加了一個簡單的 method 處理 JSON -> state machine 給 #11 。

對了，好奇為什麼 QAMachine 一開始初始化 states 不是給 `[]` 而是 `{}` ？
